### PR TITLE
1595 legger til database

### DIFF
--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -20,6 +20,16 @@ spec:
   prometheus:
     enabled: true
     path: /metrics
+  gcp:
+    sqlInstances:
+      - name: tiltakspenger-journalposthendelser
+        type: POSTGRES_17
+        tier: {{ sqlInstances.tier }}
+        diskAutoresize: {{ sqlInstances.diskAutoresize }}
+        pointInTimeRecovery: {{ sqlInstances.pointInTimeRecovery }}
+        databases:
+          - name: journalposthendelser
+            envVarPrefix: DB
   kafka:
     pool: {{ kafka-pool }}
   azure:

--- a/.nais/vars/dev.yml
+++ b/.nais/vars/dev.yml
@@ -2,6 +2,10 @@ replicas:
   min: 1
   max: 2
 kafka-pool: "nav-dev"
+sqlInstances:
+  diskAutoresize: true
+  pointInTimeRecovery: false
+  tier: db-f1-micro
 naisEnv: dev
 topic: teamdokumenthandtering.aapen-dok-journalfoering
 saf:

--- a/.nais/vars/prod.yml
+++ b/.nais/vars/prod.yml
@@ -2,6 +2,10 @@ replicas:
   min: 2
   max: 4
 kafka-pool: "nav-prod"
+sqlInstances:
+  diskAutoresize: true
+  pointInTimeRecovery: true
+  tier: db-custom-1-3840
 naisEnv: prod
 topic: teamdokumenthandtering.aapen-dok-journalfoering
 saf:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,8 @@ val avroVersion = "1.12.0"
 val caffeineVersion = "3.2.2"
 val mockkVersion = "1.14.5"
 val prometeusVersion = "1.15.4"
-
+val testContainersVersion = "1.21.3"
+val kotestVersion = "6.0.3"
 
 fun isNonStable(version: String): Boolean {
     val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.uppercase().contains(it) }
@@ -48,6 +49,8 @@ dependencies {
     implementation("com.github.navikt.tiltakspenger-libs:json:$felleslibVersion")
     implementation("com.github.navikt.tiltakspenger-libs:kafka:$felleslibVersion")
     implementation("com.github.navikt.tiltakspenger-libs:logging:$felleslibVersion")
+    implementation("com.github.navikt.tiltakspenger-libs:persistering-domene:$felleslibVersion")
+    implementation("com.github.navikt.tiltakspenger-libs:persistering-infrastruktur:$felleslibVersion")
     implementation("com.github.navikt.tiltakspenger-libs:texas:$felleslibVersion")
 
     // Align versions of all Kotlin components
@@ -78,6 +81,12 @@ dependencies {
     // Jackson
     implementation("io.ktor:ktor-serialization-jackson:${ktorVersion}")
 
+    // DB
+    implementation("org.flywaydb:flyway-database-postgresql:11.11.2")
+    implementation("com.zaxxer:HikariCP:7.0.2")
+    implementation("org.postgresql:postgresql:42.7.7")
+    implementation("com.github.seratch:kotliquery:1.9.1")
+
     // Avro
     implementation("io.confluent:kafka-avro-serializer:${confluentVersion}")
     implementation("org.apache.avro:avro:${avroVersion}")
@@ -92,6 +101,11 @@ dependencies {
     testImplementation("io.mockk:mockk:${mockkVersion}")
     testImplementation("io.mockk:mockk-dsl-jvm:${mockkVersion}")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+    testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+
+    testImplementation("org.testcontainers:testcontainers:$testContainersVersion")
+    testImplementation("org.testcontainers:junit-jupiter:$testContainersVersion")
+    testImplementation("org.testcontainers:postgresql:$testContainersVersion")
 }
 
 spotless {

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/Application.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/Application.kt
@@ -7,7 +7,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.util.AttributeKey
 import no.nav.tiltakspenger.journalposthendelser.context.ApplicationContext
-import no.nav.tiltakspenger.journalposthendelser.routes.journalposthendelser
+import no.nav.tiltakspenger.journalposthendelser.routes.setupRoutes
 
 fun main() {
     System.setProperty("logback.configurationFile", Configuration.logbackConfigFile)
@@ -20,7 +20,7 @@ fun main() {
 fun start(
     log: KLogger,
     port: Int = Configuration.applicationHttpPort,
-    applicationContext: ApplicationContext = ApplicationContext(),
+    applicationContext: ApplicationContext = ApplicationContext(log),
 ) {
     Thread.setDefaultUncaughtExceptionHandler { _, e ->
         log.error(e) { e.message }
@@ -32,7 +32,7 @@ fun start(
         factory = Netty,
         port = port,
         module = {
-            journalposthendelser()
+            setupRoutes()
         },
     )
     server.application.attributes.put(isReadyKey, true)

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/Configuration.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/Configuration.kt
@@ -19,6 +19,8 @@ object Configuration {
     val naisTokenEndpoint = getEnvVar("NAIS_TOKEN_ENDPOINT")
     val tokenExchangeEndpoint = getEnvVar("NAIS_TOKEN_EXCHANGE_ENDPOINT")
 
+    val jdbcUrl = getEnvVar("DB_JDBC_URL")
+
     fun isNais() = applicationProfile() != Profile.LOCAL
 
     fun applicationProfile() =

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/infra/db/DataSourceSetup.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/infra/db/DataSourceSetup.kt
@@ -1,0 +1,26 @@
+package no.nav.tiltakspenger.journalposthendelser.infra.db
+
+import com.zaxxer.hikari.HikariDataSource
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val LOG = KotlinLogging.logger {}
+
+object DataSourceSetup {
+    private const val MAX_POOLS = 5
+
+    fun createDatasource(
+        jdbcUrl: String,
+    ): HikariDataSource {
+        LOG.info {
+            "Kobler til Postgres. Bruker bare jdbc-urlen i config (+ timeout og maxpools)."
+        }
+
+        return HikariDataSource().apply {
+            this.jdbcUrl = jdbcUrl
+            initializationFailTimeout = 5000
+            maximumPoolSize = MAX_POOLS
+        }.also {
+            flywayMigrate(it)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/infra/db/FlywayMigrate.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/infra/db/FlywayMigrate.kt
@@ -1,0 +1,33 @@
+package no.nav.tiltakspenger.journalposthendelser.infra.db
+
+import no.nav.tiltakspenger.journalposthendelser.Configuration
+import org.flywaydb.core.Flyway
+import javax.sql.DataSource
+
+private fun flyway(dataSource: DataSource): Flyway =
+    if (Configuration.isNais()) {
+        gcpFlyway(dataSource)
+    } else {
+        localFlyway(dataSource)
+    }
+
+private fun localFlyway(dataSource: DataSource) =
+    Flyway
+        .configure()
+        .loggers("slf4j")
+        .encoding("UTF-8")
+        .locations("db/migration", "db/local-migration")
+        .dataSource(dataSource)
+        .load()
+
+private fun gcpFlyway(dataSource: DataSource) =
+    Flyway
+        .configure()
+        .loggers("slf4j")
+        .encoding("UTF-8")
+        .dataSource(dataSource)
+        .load()
+
+fun flywayMigrate(dataSource: DataSource) {
+    flyway(dataSource).migrate()
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalpostService.kt
@@ -2,6 +2,9 @@ package no.nav.tiltakspenger.journalposthendelser.journalpost
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.journalposthendelser.infra.MetricRegister
+import no.nav.tiltakspenger.journalposthendelser.journalpost.clients.saf.SafJournalpostClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.Brevkode
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.JournalpostMetadata
 
 class JournalpostService(
     private val safJournalpostClient: SafJournalpostClient,

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/clients/saf/SafJournalpostClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/clients/saf/SafJournalpostClient.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltakspenger.journalposthendelser.journalpost
+package no.nav.tiltakspenger.journalposthendelser.journalpost.clients.saf
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -9,6 +9,7 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.JournalpostMetadata
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.json.objectMapper
 import java.time.LocalDateTime

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/domene/Brevkode.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/domene/Brevkode.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltakspenger.journalposthendelser.journalpost
+package no.nav.tiltakspenger.journalposthendelser.journalpost.domene
 
 /**
  * Dokumentkoder for brevtyper vi mottar, se under IND:

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/domene/JournalpostMetadata.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/domene/JournalpostMetadata.kt
@@ -1,5 +1,7 @@
-package no.nav.tiltakspenger.journalposthendelser.journalpost
+package no.nav.tiltakspenger.journalposthendelser.journalpost.domene
 
+import no.nav.tiltakspenger.journalposthendelser.journalpost.clients.saf.Bruker
+import no.nav.tiltakspenger.journalposthendelser.journalpost.clients.saf.Dokument
 import java.time.LocalDateTime
 
 data class JournalpostMetadata(

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/kafka/JournalposthendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/kafka/JournalposthendelseConsumer.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltakspenger.journalposthendelser.journalpost
+package no.nav.tiltakspenger.journalposthendelser.journalpost.kafka
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializer
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -6,6 +6,7 @@ import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
 import no.nav.tiltakspenger.journalposthendelser.Configuration
 import no.nav.tiltakspenger.journalposthendelser.KAFKA_CONSUMER_GROUP_ID
 import no.nav.tiltakspenger.journalposthendelser.infra.MetricRegister
+import no.nav.tiltakspenger.journalposthendelser.journalpost.JournalpostService
 import no.nav.tiltakspenger.libs.kafka.Consumer
 import no.nav.tiltakspenger.libs.kafka.ManagedKafkaConsumer
 import no.nav.tiltakspenger.libs.kafka.config.KafkaConfig

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseDB.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseDB.kt
@@ -1,0 +1,16 @@
+package no.nav.tiltakspenger.journalposthendelser.journalpost.repository
+
+import java.time.LocalDateTime
+
+data class JournalposthendelseDB(
+    val journalpostId: String,
+    val fnr: String?,
+    val saksnummer: String?,
+    val brevkode: String?,
+    val journalpostOppdatertTidspunkt: LocalDateTime?,
+    val oppgaveId: String?,
+    val oppgavetype: String?,
+    val oppgaveOpprettetTidspunkt: LocalDateTime?,
+    val opprettet: LocalDateTime,
+    val sistEndret: LocalDateTime,
+)

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseRepo.kt
@@ -1,0 +1,103 @@
+package no.nav.tiltakspenger.journalposthendelser.journalpost.repository
+
+import kotliquery.Row
+import kotliquery.queryOf
+import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
+
+class JournalposthendelseRepo(
+    private val sessionFactory: PostgresSessionFactory,
+) {
+    fun hent(
+        journalpostId: String,
+    ): JournalposthendelseDB? {
+        return sessionFactory.withSession { session ->
+            session.run(
+                queryOf(
+                    //language=sql
+                    """
+                    select *
+                    from journalposthendelse
+                    where journalpost_id = :journalpost_id;
+                    """.trimIndent(),
+                    mapOf(
+                        "journalpost_id" to journalpostId,
+                    ),
+                ).map { fromRow(it) }.asSingle,
+            )
+        }
+    }
+
+    fun lagre(
+        journalposthendelseDB: JournalposthendelseDB,
+    ) {
+        sessionFactory.withSession { session ->
+            session.run(
+                queryOf(
+                    lagreJournalposthendelseSql,
+                    mapOf(
+                        "journalpost_id" to journalposthendelseDB.journalpostId,
+                        "fnr" to journalposthendelseDB.fnr,
+                        "saksnummer" to journalposthendelseDB.saksnummer,
+                        "brevkode" to journalposthendelseDB.brevkode,
+                        "journalpost_oppdatert_tidspunkt" to journalposthendelseDB.journalpostOppdatertTidspunkt,
+                        "oppgave_id" to journalposthendelseDB.oppgaveId,
+                        "oppgavetype" to journalposthendelseDB.oppgavetype,
+                        "oppgave_opprettet_tidspunkt" to journalposthendelseDB.oppgaveOpprettetTidspunkt,
+                        "opprettet" to journalposthendelseDB.opprettet,
+                        "sist_endret" to journalposthendelseDB.sistEndret,
+                    ),
+                ).asUpdate,
+            )
+        }
+    }
+
+    private fun fromRow(row: Row): JournalposthendelseDB {
+        return JournalposthendelseDB(
+            journalpostId = (row.string("journalpost_id")),
+            fnr = row.stringOrNull("fnr"),
+            saksnummer = row.stringOrNull("saksnummer"),
+            brevkode = row.stringOrNull("brevkode"),
+            journalpostOppdatertTidspunkt = row.localDateTimeOrNull("journalpost_oppdatert_tidspunkt"),
+            oppgaveId = row.stringOrNull("oppgave_id"),
+            oppgavetype = row.stringOrNull("oppgavetype"),
+            oppgaveOpprettetTidspunkt = row.localDateTimeOrNull("oppgave_opprettet_tidspunkt"),
+            opprettet = row.localDateTime("opprettet"),
+            sistEndret = row.localDateTime("sist_endret"),
+        )
+    }
+
+    private val lagreJournalposthendelseSql =
+        """
+        insert into journalposthendelse (
+        journalpost_id,
+        fnr,
+        saksnummer,
+        brevkode,
+        journalpost_oppdatert_tidspunkt,
+        oppgave_id,
+        oppgavetype,
+        oppgave_opprettet_tidspunkt,
+        opprettet,
+        sist_endret
+        ) values (
+        :journalpost_id,
+        :fnr,
+        :saksnummer,
+        :brevkode,
+        :journalpost_oppdatert_tidspunkt,
+        :oppgave_id,
+        :oppgavetype,
+        :oppgave_opprettet_tidspunkt,
+        :opprettet,
+        :sist_endret
+        ) on conflict (journalpost_id) do update set
+        fnr = :fnr,
+        saksnummer = :saksnummer,
+        brevkode = :brevkode,
+        journalpost_oppdatert_tidspunkt = :journalpost_oppdatert_tidspunkt,
+        oppgave_id = :oppgave_id,
+        oppgavetype = :oppgavetype,
+        oppgave_opprettet_tidspunkt = :oppgave_opprettet_tidspunkt,
+        sist_endret = :sist_endret
+        """.trimIndent()
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/routes/RouteSettings.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/routes/RouteSettings.kt
@@ -11,7 +11,7 @@ import io.micrometer.prometheusmetrics.PrometheusConfig
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 
-fun Application.journalposthendelser() {
+fun Application.setupRoutes() {
     routing { healthRoutes() }
     metrics()
 }

--- a/src/main/resources/db/migration/V1__Tabeller.sql
+++ b/src/main/resources/db/migration/V1__Tabeller.sql
@@ -1,0 +1,32 @@
+DO
+$$
+    BEGIN
+        IF
+            EXISTS
+                    (SELECT 1 from pg_roles where rolname = 'cloudsqliamuser')
+        THEN
+            GRANT USAGE ON SCHEMA public TO cloudsqliamuser;
+            GRANT
+                SELECT
+                ON ALL TABLES IN SCHEMA public TO cloudsqliamuser;
+            ALTER
+                DEFAULT PRIVILEGES IN SCHEMA public GRANT
+                SELECT
+                ON TABLES TO cloudsqliamuser;
+        END IF;
+    END
+$$;
+
+CREATE TABLE journalposthendelse
+(
+    journalpost_id                  VARCHAR PRIMARY KEY,
+    fnr                             VARCHAR,
+    saksnummer                      VARCHAR,
+    brevkode                        VARCHAR,
+    journalpost_oppdatert_tidspunkt timestamp with time zone,
+    oppgave_id                      VARCHAR,
+    oppgavetype                     VARCHAR,
+    oppgave_opprettet_tidspunkt     timestamp with time zone,
+    opprettet                       timestamp with time zone default CURRENT_TIMESTAMP not null,
+    sist_endret                     timestamp with time zone default CURRENT_TIMESTAMP not null
+);

--- a/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalpostServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalpostServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.tiltakspenger.journalposthendelser.journalpost
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.journalposthendelser.journalpost.clients.saf.SafJournalpostClient
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 

--- a/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalposthendelseConsumerTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalposthendelseConsumerTest.kt
@@ -7,6 +7,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
+import no.nav.tiltakspenger.journalposthendelser.journalpost.kafka.JournalposthendelseConsumer
 import no.nav.tiltakspenger.libs.kafka.config.LocalKafkaConfig
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseRepoTest.kt
@@ -1,0 +1,81 @@
+package no.nav.tiltakspenger.journalposthendelser.journalpost.repository
+
+import io.kotest.matchers.shouldBe
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.Brevkode
+import no.nav.tiltakspenger.journalposthendelser.testutils.shouldBeCloseTo
+import no.nav.tiltakspenger.journalposthendelser.testutils.withMigratedDb
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class JournalposthendelseRepoTest {
+    @Test
+    fun `kan lagre og hente journalposthendelse`() {
+        withMigratedDb { testDataHelper ->
+            val repo = testDataHelper.journalposthendelseRepo
+            val journalposthendelseDB = JournalposthendelseDB(
+                journalpostId = "1234567",
+                fnr = "12345678910",
+                brevkode = Brevkode.SØKNAD.brevkode,
+                saksnummer = "202509151003",
+                journalpostOppdatertTidspunkt = LocalDateTime.now().minusMinutes(2),
+                oppgaveId = "900000",
+                oppgavetype = "BEHANDLE_SAK",
+                oppgaveOpprettetTidspunkt = LocalDateTime.now().minusMinutes(1),
+                opprettet = LocalDateTime.now().minusMinutes(5),
+                sistEndret = LocalDateTime.now(),
+            )
+
+            repo.lagre(journalposthendelseDB)
+
+            val journalposthendelseFraDb = repo.hent(journalposthendelseDB.journalpostId)
+            journalposthendelseFraDb?.fnr shouldBe journalposthendelseDB.fnr
+            journalposthendelseFraDb?.brevkode shouldBe journalposthendelseDB.brevkode
+            journalposthendelseFraDb?.saksnummer shouldBe journalposthendelseDB.saksnummer
+            journalposthendelseFraDb?.journalpostOppdatertTidspunkt shouldBeCloseTo journalposthendelseDB.journalpostOppdatertTidspunkt
+            journalposthendelseFraDb?.oppgaveId shouldBe journalposthendelseDB.oppgaveId
+            journalposthendelseFraDb?.oppgavetype shouldBe journalposthendelseDB.oppgavetype
+            journalposthendelseFraDb?.oppgaveOpprettetTidspunkt shouldBeCloseTo journalposthendelseDB.oppgaveOpprettetTidspunkt
+            journalposthendelseFraDb?.opprettet shouldBeCloseTo journalposthendelseDB.opprettet
+            journalposthendelseFraDb?.sistEndret shouldBeCloseTo journalposthendelseDB.sistEndret
+        }
+    }
+
+    @Test
+    fun `kan oppdatere journalposthendelse`() {
+        withMigratedDb { testDataHelper ->
+            val repo = testDataHelper.journalposthendelseRepo
+            val journalposthendelseDB = JournalposthendelseDB(
+                journalpostId = "1234567",
+                fnr = "12345678910",
+                brevkode = Brevkode.SØKNAD.brevkode,
+                saksnummer = "202509151003",
+                journalpostOppdatertTidspunkt = LocalDateTime.now().minusMinutes(2),
+                oppgaveId = null,
+                oppgavetype = null,
+                oppgaveOpprettetTidspunkt = null,
+                opprettet = LocalDateTime.now().minusMinutes(5),
+                sistEndret = LocalDateTime.now().minusMinutes(2),
+            )
+            repo.lagre(journalposthendelseDB)
+
+            val oppdatertJournalposthendelseDB = journalposthendelseDB.copy(
+                oppgaveId = "900000",
+                oppgavetype = "BEHANDLE_SAK",
+                oppgaveOpprettetTidspunkt = LocalDateTime.now().minusMinutes(1),
+                sistEndret = LocalDateTime.now(),
+            )
+            repo.lagre(oppdatertJournalposthendelseDB)
+
+            val journalposthendelseFraDb = repo.hent(oppdatertJournalposthendelseDB.journalpostId)
+            journalposthendelseFraDb?.fnr shouldBe oppdatertJournalposthendelseDB.fnr
+            journalposthendelseFraDb?.brevkode shouldBe oppdatertJournalposthendelseDB.brevkode
+            journalposthendelseFraDb?.saksnummer shouldBe oppdatertJournalposthendelseDB.saksnummer
+            journalposthendelseFraDb?.journalpostOppdatertTidspunkt shouldBeCloseTo oppdatertJournalposthendelseDB.journalpostOppdatertTidspunkt
+            journalposthendelseFraDb?.oppgaveId shouldBe oppdatertJournalposthendelseDB.oppgaveId
+            journalposthendelseFraDb?.oppgavetype shouldBe oppdatertJournalposthendelseDB.oppgavetype
+            journalposthendelseFraDb?.oppgaveOpprettetTidspunkt shouldBeCloseTo oppdatertJournalposthendelseDB.oppgaveOpprettetTidspunkt
+            journalposthendelseFraDb?.opprettet shouldBeCloseTo oppdatertJournalposthendelseDB.opprettet
+            journalposthendelseFraDb?.sistEndret shouldBeCloseTo oppdatertJournalposthendelseDB.sistEndret
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/testutils/DateTimeAssertions.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/testutils/DateTimeAssertions.kt
@@ -1,0 +1,14 @@
+package no.nav.tiltakspenger.journalposthendelser.testutils
+
+import io.kotest.matchers.date.shouldBeWithin
+import io.kotest.matchers.shouldBe
+import java.time.Duration
+import java.time.LocalDateTime
+
+infix fun LocalDateTime?.shouldBeCloseTo(expected: LocalDateTime?) {
+    if (this == null) {
+        expected shouldBe null
+    } else {
+        expected!!.shouldBeWithin(Duration.ofSeconds(10), this)
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/testutils/TestDataHelper.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/testutils/TestDataHelper.kt
@@ -1,0 +1,25 @@
+package no.nav.tiltakspenger.journalposthendelser.testutils
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tiltakspenger.journalposthendelser.journalpost.repository.JournalposthendelseRepo
+import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
+import no.nav.tiltakspenger.libs.persistering.infrastruktur.SessionCounter
+import javax.sql.DataSource
+
+internal class TestDataHelper(
+    private val dataSource: DataSource,
+) {
+    private val log = KotlinLogging.logger {}
+    private val sessionCounter = SessionCounter(log)
+    val sessionFactory = PostgresSessionFactory(dataSource, sessionCounter)
+    val journalposthendelseRepo = JournalposthendelseRepo(sessionFactory)
+}
+
+private val dbManager = TestDatabaseManager()
+
+/**
+ * @param runIsolated Tømmer databasen før denne testen for kjøre i isolasjon. Brukes når man gjør operasjoner på tvers av saker.
+ */
+internal fun withMigratedDb(runIsolated: Boolean = true, test: (TestDataHelper) -> Unit) {
+    dbManager.withMigratedDb(runIsolated, test)
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/testutils/TestDatabaseManager.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/testutils/TestDatabaseManager.kt
@@ -1,0 +1,111 @@
+package no.nav.tiltakspenger.journalposthendelser.testutils
+
+import com.zaxxer.hikari.HikariDataSource
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.util.date.getTimeMillis
+import kotliquery.sessionOf
+import no.nav.tiltakspenger.libs.persistering.infrastruktur.sqlQuery
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.output.MigrateResult
+import org.testcontainers.containers.PostgreSQLContainer
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import javax.sql.DataSource
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+/**
+ * Lånt fra tiltakspenger-saksbehandling-api
+ */
+internal class TestDatabaseManager {
+
+    private val log = KotlinLogging.logger {}
+
+    private val postgres: PostgreSQLContainer<Nothing> by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        PostgreSQLContainer<Nothing>("postgres:17-alpine").apply { start() }
+    }
+
+    private val dataSource: HikariDataSource by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        HikariDataSource().apply {
+            this.jdbcUrl = postgres.jdbcUrl
+            this.maximumPoolSize = 100
+            this.minimumIdle = 1
+            this.idleTimeout = 10001
+            this.connectionTimeout = 1000
+            this.maxLifetime = 30001
+            this.username = postgres.username
+            this.password = postgres.password
+            initializationFailTimeout = 5000
+        }.also {
+            migrateDatabase(it)
+        }
+    }
+
+    private val counter = AtomicInteger(0)
+
+    private val started: Long by lazy { getTimeMillis() }
+
+    @Volatile
+    private var isClosed = false
+    private val lock = ReentrantReadWriteLock()
+
+    /**
+     * @param runIsolated Tømmer databasen før denne testen for kjøre i isolasjon.
+     */
+    fun withMigratedDb(runIsolated: Boolean = false, test: (TestDataHelper) -> Unit) {
+        if (isClosed) {
+            throw IllegalStateException("The test database is closed.")
+        }
+        counter.incrementAndGet()
+        try {
+            if (runIsolated) {
+                lock.write {
+                    cleanDatabase()
+                    test(TestDataHelper(dataSource))
+                }
+            } else {
+                lock.read {
+                    test(TestDataHelper(dataSource))
+                }
+            }
+        } finally {
+            if (getTimeMillis() - started > 10 && counter.get() == 0) {
+                close()
+            }
+        }
+        counter.decrementAndGet()
+    }
+
+    private fun cleanDatabase() {
+        sessionOf(dataSource).run(
+            sqlQuery(
+                """
+                TRUNCATE
+                  journalposthendelse
+                """,
+            ).asUpdate,
+        )
+    }
+
+    private fun close() {
+        if (!isClosed) {
+            log.info { "Stenger testdatabasen" }
+            dataSource.close()
+            postgres.stop()
+            isClosed = true
+        } else {
+            log.info { "Testdatabasen er allerede stengt. Vi gjør ingenting." }
+        }
+    }
+
+    private fun migrateDatabase(dataSource: DataSource): MigrateResult? {
+        return Flyway
+            .configure()
+            .loggers("slf4j")
+            .encoding("UTF-8")
+            .locations("db/migration")
+            .dataSource(dataSource)
+            .load()
+            .migrate()
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %green(%d{HH:mm:ss.SSS}) %yellow([%thread]) %highlight(%-5level) %cyan(%logger{36}) - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <logger name="ch.qos.logback" level="WARN"/>
+    <logger name="org.apache.kafka" level="WARN"/>
+    <logger name="org.flywaydb" level="WARN"/>
+    <logger name="com.zaxxer" level="WARN"/>
+    <logger name="io.ktor.auth.jwt" level="TRACE"/>
+    <logger name="team-logs-logger" level="DEBUG" additivity="false">
+        <appender-ref ref="team-logs"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Opprettet database med en tabell der vi kan holde oversikt over hva som er gjort med journalposthendelsene som vi skal behandle så vi vet hva som evt gjenstår hvis meldingen leses på nytt. Har også endret litt på pakkestrukturen og lagt til diverse som trengtes for tester. 

https://trello.com/c/hAyNLNOc/1595-h%C3%A5ndtere-alle-journalposthendelser-som-gjelder-tiltakspenger-inkludert-scannede-papirs%C3%B8knader-toggles-av-i-prod