### PR TITLE
1595 behandler journalposthendelser

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/context/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/context/ApplicationContext.kt
@@ -5,6 +5,8 @@ import no.nav.tiltakspenger.journalposthendelser.Configuration
 import no.nav.tiltakspenger.journalposthendelser.infra.db.DataSourceSetup
 import no.nav.tiltakspenger.journalposthendelser.infra.httpClientApache
 import no.nav.tiltakspenger.journalposthendelser.journalpost.JournalpostService
+import no.nav.tiltakspenger.journalposthendelser.journalpost.JournalposthendelseService
+import no.nav.tiltakspenger.journalposthendelser.journalpost.OppgaveService
 import no.nav.tiltakspenger.journalposthendelser.journalpost.http.dokarkiv.DokarkivClient
 import no.nav.tiltakspenger.journalposthendelser.journalpost.http.oppgave.OppgaveClient
 import no.nav.tiltakspenger.journalposthendelser.journalpost.http.pdl.PdlClient
@@ -89,11 +91,25 @@ open class ApplicationContext(log: KLogger) {
     )
 
     val journalpostService = JournalpostService(
+        saksbehandlingApiClient = saksbehandlingApiClient,
+        dokarkivClient = dokarkivClient,
+        journalposthendelseRepo = journalposthendelseRepo,
+    )
+    val oppgaveService = OppgaveService(
+        oppgaveClient = oppgaveClient,
+        journalposthendelseRepo = journalposthendelseRepo,
+    )
+
+    val journalposthendelseService = JournalposthendelseService(
         safJournalpostClient = safJournalpostClient,
+        journalposthendelseRepo = journalposthendelseRepo,
+        pdlClient = pdlClient,
+        journalpostService = journalpostService,
+        oppgaveService = oppgaveService,
     )
 
     val journalposthendelseConsumer = JournalposthendelseConsumer(
         topic = Configuration.topic,
-        journalpostService = journalpostService,
+        journalposthendelseService = journalposthendelseService,
     )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalposthendelseService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalposthendelseService.kt
@@ -1,0 +1,111 @@
+package no.nav.tiltakspenger.journalposthendelser.journalpost
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tiltakspenger.journalposthendelser.Configuration
+import no.nav.tiltakspenger.journalposthendelser.infra.MetricRegister
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.Brevkode
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.JournalpostMetadata
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.pdl.PdlClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.saf.SafJournalpostClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.repository.JournalposthendelseDB
+import no.nav.tiltakspenger.journalposthendelser.journalpost.repository.JournalposthendelseRepo
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import java.time.LocalDateTime
+
+class JournalposthendelseService(
+    private val safJournalpostClient: SafJournalpostClient,
+    private val journalposthendelseRepo: JournalposthendelseRepo,
+    private val pdlClient: PdlClient,
+    private val journalpostService: JournalpostService,
+    private val oppgaveService: OppgaveService,
+) {
+    val log = KotlinLogging.logger {}
+
+    suspend fun behandleJournalpostHendelse(journalpostId: String) {
+        val correlationId = CorrelationId.generate()
+        val journalpostMetadata = safJournalpostClient.getJournalpostMetadata(journalpostId.toString())
+            ?: throw IllegalStateException(
+                "Unable to find journalpost with id $journalpostId",
+            )
+
+        log.info {
+            """Journalpost journalpostId=$journalpostId,
+                erJournalfort=${journalpostMetadata.erJournalfort},
+                datoOpprettet=${journalpostMetadata.datoOpprettet},
+                brevkode=${journalpostMetadata.brevkode},
+            """.trimIndent()
+        }
+
+        val journalposthendelseDB = journalposthendelseRepo.hent(journalpostId)
+
+        // Skal ikke behandle disse ennå
+        if (!Configuration.isNais()) {
+            if (skalBehandleJournalposthendelse(journalposthendelseDB, journalpostMetadata)) {
+                log.info { "Behandler mottatt journalpost $journalpostId" }
+                registrerMetrikker(journalpostMetadata)
+                val journalposthendelseDBUnderArbeid = journalposthendelseDB ?: JournalposthendelseDB(
+                    journalpostId = journalpostId,
+                    brevkode = journalpostMetadata.brevkode,
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                val fnr = hentIdent(journalpostMetadata)
+                if (fnr == null) {
+                    log.warn { "Fant ikke person for journalpost med id $journalpostId, oppretter fordelingsoppgave" }
+                    oppgaveService.opprettFordelingsoppgave(journalposthendelseDBUnderArbeid, correlationId)
+                } else {
+                    val oppdatertJournalposthendelseDB = journalpostService.oppdaterEllerFerdigstillJournalpost(
+                        journalposthendelseDB = journalposthendelseDBUnderArbeid.copy(fnr = fnr),
+                        correlationId = correlationId,
+                    )
+                    if (oppdatertJournalposthendelseDB.gjelderPapirsoknad()) {
+                        oppgaveService.opprettOppgaveForPapirsoknad(oppdatertJournalposthendelseDB, correlationId)
+                    } else {
+                        oppgaveService.opprettJournalforingsoppgave(
+                            journalposthendelseDB = oppdatertJournalposthendelseDB,
+                            tittel = journalpostMetadata.tittel,
+                            correlationId = correlationId,
+                        )
+                    }
+                }
+                log.info { "Ferdig med å behandle mottatt journalpost $journalpostId" }
+            }
+        } else {
+            if (!journalpostMetadata.erJournalfort) {
+                registrerMetrikker(journalpostMetadata)
+            }
+        }
+    }
+
+    private fun skalBehandleJournalposthendelse(
+        journalposthendelseDB: JournalposthendelseDB?,
+        journalpostMetadata: JournalpostMetadata,
+    ) =
+        !journalpostMetadata.erJournalfort || (journalposthendelseDB != null && !journalposthendelseDB.erFerdigBehandlet())
+
+    private suspend fun hentIdent(journalpostMetadata: JournalpostMetadata): String? {
+        if (journalpostMetadata.manglerBruker()) {
+            log.warn { "Journalpost med id ${journalpostMetadata.journalpostId} mangler bruker" }
+            return null
+        }
+        return journalpostMetadata.bruker.id?.let {
+            pdlClient.hentGjeldendeIdent(
+                fnr = it,
+                journalpostId = journalpostMetadata.journalpostId,
+            )
+        }
+    }
+
+    private fun registrerMetrikker(journalpost: JournalpostMetadata) {
+        if (journalpost.brevkode == Brevkode.SØKNAD.brevkode) {
+            MetricRegister.SØKNAD_MOTTATT.inc()
+        } else if (journalpost.brevkode == Brevkode.KLAGE.brevkode) {
+            MetricRegister.KLAGE_MOTTATT.inc()
+        } else if (journalpost.brevkode == Brevkode.MELDEKORT.brevkode) {
+            MetricRegister.MELDEKORT_MOTTATT.inc()
+        } else {
+            log.info { "Annen brevkode mottatt: ${journalpost.brevkode}" }
+            MetricRegister.ANNEN_BREVKODE_MOTTATT.inc()
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/OppgaveService.kt
@@ -1,0 +1,86 @@
+package no.nav.tiltakspenger.journalposthendelser.journalpost
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.oppgave.OppgaveClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.oppgave.OppgaveType
+import no.nav.tiltakspenger.journalposthendelser.journalpost.repository.JournalposthendelseDB
+import no.nav.tiltakspenger.journalposthendelser.journalpost.repository.JournalposthendelseRepo
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import java.time.LocalDateTime
+
+class OppgaveService(
+    private val oppgaveClient: OppgaveClient,
+    private val journalposthendelseRepo: JournalposthendelseRepo,
+) {
+    val log = KotlinLogging.logger {}
+
+    suspend fun opprettOppgaveForPapirsoknad(
+        journalposthendelseDB: JournalposthendelseDB,
+        correlationId: CorrelationId,
+    ) {
+        if (!journalposthendelseDB.harOpprettetOppgave() && journalposthendelseDB.harFerdigstiltJournalpost()) {
+            val oppgaveId = oppgaveClient.opprettOppgaveForPapirsoknad(
+                fnr = journalposthendelseDB.fnr!!,
+                journalpostId = journalposthendelseDB.journalpostId,
+                correlationId = correlationId,
+            )
+            val oppdatertJournalposthendelseDB = journalposthendelseDB.copy(
+                oppgaveId = oppgaveId.toString(),
+                oppgavetype = OppgaveType.BEHANDLE_SAK,
+                oppgaveOpprettetTidspunkt = LocalDateTime.now(),
+                sistEndret = LocalDateTime.now(),
+            )
+            journalposthendelseRepo.lagre(oppdatertJournalposthendelseDB)
+            log.info { "Opprettet behandle sak-oppgave for journalpost med id ${journalposthendelseDB.journalpostId}" }
+        } else {
+            log.warn { "Har allerede opprettet oppgave for journalpost med is ${journalposthendelseDB.journalpostId}" }
+        }
+    }
+
+    suspend fun opprettJournalforingsoppgave(
+        journalposthendelseDB: JournalposthendelseDB,
+        tittel: String?,
+        correlationId: CorrelationId,
+    ) {
+        if (!journalposthendelseDB.harOpprettetOppgave() && journalposthendelseDB.harOppdatertJournalpost()) {
+            val oppgaveId = oppgaveClient.opprettJournalforingsoppgave(
+                fnr = journalposthendelseDB.fnr!!,
+                journalpostId = journalposthendelseDB.journalpostId,
+                journalpostTittel = tittel ?: "Mottatt dokument",
+                correlationId = correlationId,
+            )
+            val oppdatertJournalposthendelseDB = journalposthendelseDB.copy(
+                oppgaveId = oppgaveId.toString(),
+                oppgavetype = OppgaveType.JOURNALFORING,
+                oppgaveOpprettetTidspunkt = LocalDateTime.now(),
+                sistEndret = LocalDateTime.now(),
+            )
+            journalposthendelseRepo.lagre(oppdatertJournalposthendelseDB)
+            log.info { "Opprettet journalføringsoppgave for journalpost med id ${journalposthendelseDB.journalpostId}" }
+        } else {
+            log.info { "Har allerede opprettet oppgave for journalpost med is ${journalposthendelseDB.journalpostId}" }
+        }
+    }
+
+    suspend fun opprettFordelingsoppgave(
+        journalposthendelseDB: JournalposthendelseDB,
+        correlationId: CorrelationId,
+    ) {
+        if (!journalposthendelseDB.harOpprettetOppgave() && journalposthendelseDB.manglerBruker()) {
+            val oppgaveId = oppgaveClient.opprettFordelingsoppgave(
+                journalpostId = journalposthendelseDB.journalpostId,
+                correlationId = correlationId,
+            )
+            val oppdatertJournalposthendelseDB = journalposthendelseDB.copy(
+                oppgaveId = oppgaveId.toString(),
+                oppgavetype = OppgaveType.FORDELING,
+                oppgaveOpprettetTidspunkt = LocalDateTime.now(),
+                sistEndret = LocalDateTime.now(),
+            )
+            journalposthendelseRepo.lagre(oppdatertJournalposthendelseDB)
+            log.info { "Opprettet fordelingsoppgave for journalpost med id ${journalposthendelseDB.journalpostId}" }
+        } else {
+            log.info { "Har allerede opprettet oppgave for journalpost med is ${journalposthendelseDB.journalpostId}" }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/domene/JournalpostMetadata.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/domene/JournalpostMetadata.kt
@@ -1,13 +1,15 @@
 package no.nav.tiltakspenger.journalposthendelser.journalpost.domene
 
 import no.nav.tiltakspenger.journalposthendelser.journalpost.http.saf.Bruker
-import no.nav.tiltakspenger.journalposthendelser.journalpost.http.saf.Dokument
 import java.time.LocalDateTime
 
 data class JournalpostMetadata(
+    val journalpostId: String,
     val bruker: Bruker,
-    val dokumenter: List<Dokument>?,
-    val journalpostErIkkeJournalfort: Boolean,
+    val erJournalfort: Boolean,
     val datoOpprettet: LocalDateTime?,
-    val dokumentInfoIdPdf: String?,
-)
+    val brevkode: String?,
+    val tittel: String?,
+) {
+    fun manglerBruker() = bruker.id == null || bruker.type == null
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/http/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/http/pdl/PdlClient.kt
@@ -16,6 +16,10 @@ import no.nav.tiltakspenger.journalposthendelser.infra.graphql.GraphQLResponse
 import no.nav.tiltakspenger.libs.common.AccessToken
 import no.nav.tiltakspenger.libs.json.objectMapper
 
+/**
+ * https://pdl-docs.ansatt.nav.no/ekstern/index.html
+ * Spørringen henter ikke historiske identer, kun gjeldende.
+ */
 class PdlClient(
     private val httpClient: HttpClient,
     private val basePath: String,

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseDB.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseDB.kt
@@ -1,17 +1,47 @@
 package no.nav.tiltakspenger.journalposthendelser.journalpost.repository
 
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.Brevkode
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.oppgave.OppgaveType
 import java.time.LocalDateTime
 
 data class JournalposthendelseDB(
     val journalpostId: String,
-    val fnr: String?,
-    val saksnummer: String?,
-    val brevkode: String?,
-    val journalpostOppdatertTidspunkt: LocalDateTime?,
-    val journalpostFerdigstiltTidspunkt: LocalDateTime?,
-    val oppgaveId: String?,
-    val oppgavetype: String?,
-    val oppgaveOpprettetTidspunkt: LocalDateTime?,
+    val fnr: String? = null,
+    val saksnummer: String? = null,
+    val brevkode: String? = null,
+    val journalpostOppdatertTidspunkt: LocalDateTime? = null,
+    val journalpostFerdigstiltTidspunkt: LocalDateTime? = null,
+    val oppgaveId: String? = null,
+    val oppgavetype: OppgaveType? = null,
+    val oppgaveOpprettetTidspunkt: LocalDateTime? = null,
     val opprettet: LocalDateTime,
     val sistEndret: LocalDateTime,
-)
+) {
+    fun gjelderPapirsoknad() = brevkode == Brevkode.SØKNAD.brevkode
+
+    fun kanOppdatereJournalpost() = fnr != null
+
+    fun harOppdatertJournalpost() = fnr != null && saksnummer != null && journalpostOppdatertTidspunkt != null
+
+    fun harFerdigstiltJournalpost() = journalpostFerdigstiltTidspunkt != null
+
+    fun manglerBruker() = fnr == null
+
+    fun harOpprettetOppgave() = oppgaveId != null && oppgavetype != null && oppgaveOpprettetTidspunkt != null
+
+    fun erFerdigBehandlet(): Boolean {
+        return if (gjelderPapirsoknad() && fnr != null) {
+            soknadErFerdigBehandlet()
+        } else if (fnr != null) {
+            journalpostMedFnrErFerdigBehandlet()
+        } else {
+            journalpostUtenFnrErFerdigBehandlet()
+        }
+    }
+
+    private fun soknadErFerdigBehandlet() = harOppdatertJournalpost() && harFerdigstiltJournalpost() && harOpprettetOppgave()
+
+    private fun journalpostMedFnrErFerdigBehandlet() = harOppdatertJournalpost() && harOpprettetOppgave()
+
+    private fun journalpostUtenFnrErFerdigBehandlet() = harOpprettetOppgave()
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseRepo.kt
@@ -2,6 +2,7 @@ package no.nav.tiltakspenger.journalposthendelser.journalpost.repository
 
 import kotliquery.Row
 import kotliquery.queryOf
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.oppgave.OppgaveType
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
 
 class JournalposthendelseRepo(
@@ -42,7 +43,7 @@ class JournalposthendelseRepo(
                         "journalpost_oppdatert_tidspunkt" to journalposthendelseDB.journalpostOppdatertTidspunkt,
                         "journalpost_ferdigstilt_tidspunkt" to journalposthendelseDB.journalpostFerdigstiltTidspunkt,
                         "oppgave_id" to journalposthendelseDB.oppgaveId,
-                        "oppgavetype" to journalposthendelseDB.oppgavetype,
+                        "oppgavetype" to journalposthendelseDB.oppgavetype?.name,
                         "oppgave_opprettet_tidspunkt" to journalposthendelseDB.oppgaveOpprettetTidspunkt,
                         "opprettet" to journalposthendelseDB.opprettet,
                         "sist_endret" to journalposthendelseDB.sistEndret,
@@ -61,7 +62,7 @@ class JournalposthendelseRepo(
             journalpostOppdatertTidspunkt = row.localDateTimeOrNull("journalpost_oppdatert_tidspunkt"),
             journalpostFerdigstiltTidspunkt = row.localDateTimeOrNull("journalpost_ferdigstilt_tidspunkt"),
             oppgaveId = row.stringOrNull("oppgave_id"),
-            oppgavetype = row.stringOrNull("oppgavetype"),
+            oppgavetype = row.stringOrNull("oppgavetype")?.let { OppgaveType.valueOf(it) },
             oppgaveOpprettetTidspunkt = row.localDateTimeOrNull("oppgave_opprettet_tidspunkt"),
             opprettet = row.localDateTime("opprettet"),
             sistEndret = row.localDateTime("sist_endret"),

--- a/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalpostServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalpostServiceTest.kt
@@ -1,21 +1,279 @@
 package no.nav.tiltakspenger.journalposthendelser.journalpost
 
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import no.nav.tiltakspenger.journalposthendelser.journalpost.http.saf.SafJournalpostClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.Brevkode
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.dokarkiv.DokarkivClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.saksbehandlingapi.SaksbehandlingApiClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.repository.JournalposthendelseDB
+import no.nav.tiltakspenger.journalposthendelser.testutils.withMigratedDb
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
 
 class JournalpostServiceTest {
-    private val safJournalpostClient = mockk<SafJournalpostClient>()
-    private val journalpostService = JournalpostService(
-        safJournalpostClient = safJournalpostClient,
-    )
+    private val saksbehandlingApiClient = mockk<SaksbehandlingApiClient>()
+    private val dokarkivClient = mockk<DokarkivClient>(relaxed = true)
+    private val saksnummer = "34567"
+
+    @BeforeEach
+    fun clearMockData() {
+        clearMocks(saksbehandlingApiClient, dokarkivClient)
+        coEvery { saksbehandlingApiClient.hentEllerOpprettSaksnummer(any(), any()) } returns saksnummer
+    }
 
     @Test
-    fun `kaster feil om klienten ikke returnerer en journalpost`() = runTest {
-        coEvery { safJournalpostClient.getJournalpostMetadata(any()) } returns null
-        assertThrows<IllegalStateException> { journalpostService.hentJournalpost(123L) }
+    fun `oppdaterEllerFerdigstillJournalpost - papirsoknad - oppdaterer og ferdigstiller`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalpostService =
+                    JournalpostService(saksbehandlingApiClient, dokarkivClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = "4567",
+                    fnr = "12345678910",
+                    brevkode = Brevkode.SØKNAD.brevkode,
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                val returnertJournalposthendelseDB = journalpostService.oppdaterEllerFerdigstillJournalpost(
+                    journalposthendelseDB,
+                    CorrelationId.generate(),
+                )
+
+                returnertJournalposthendelseDB.saksnummer shouldBe saksnummer
+                returnertJournalposthendelseDB.journalpostOppdatertTidspunkt shouldNotBe null
+                returnertJournalposthendelseDB.journalpostFerdigstiltTidspunkt shouldNotBe null
+                returnertJournalposthendelseDB.oppgaveId shouldBe null
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.saksnummer shouldBe saksnummer
+                journalposthendelseFraDB?.journalpostOppdatertTidspunkt shouldNotBe null
+                journalposthendelseFraDB?.journalpostFerdigstiltTidspunkt shouldNotBe null
+                journalposthendelseFraDB?.oppgaveId shouldBe null
+
+                coVerify(exactly = 1) {
+                    saksbehandlingApiClient.hentEllerOpprettSaksnummer(
+                        journalposthendelseDB.fnr!!,
+                        any(),
+                    )
+                }
+                coVerify(exactly = 1) {
+                    dokarkivClient.knyttSakTilJournalpost(
+                        journalposthendelseDB.journalpostId,
+                        saksnummer,
+                        any(),
+                    )
+                }
+                coVerify(exactly = 1) {
+                    dokarkivClient.ferdigstillJournalpost(
+                        journalposthendelseDB.journalpostId,
+                        any(),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `oppdaterEllerFerdigstillJournalpost - papirsoknad, oppdatert, ikke ferdigstilt - ferdigstiller`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalpostService =
+                    JournalpostService(saksbehandlingApiClient, dokarkivClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = "4567",
+                    fnr = "12345678910",
+                    brevkode = Brevkode.SØKNAD.brevkode,
+                    saksnummer = saksnummer,
+                    journalpostOppdatertTidspunkt = LocalDateTime.now(),
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                val returnertJournalposthendelseDB = journalpostService.oppdaterEllerFerdigstillJournalpost(
+                    journalposthendelseDB,
+                    CorrelationId.generate(),
+                )
+
+                returnertJournalposthendelseDB.saksnummer shouldBe saksnummer
+                returnertJournalposthendelseDB.journalpostOppdatertTidspunkt shouldNotBe null
+                returnertJournalposthendelseDB.journalpostFerdigstiltTidspunkt shouldNotBe null
+                returnertJournalposthendelseDB.oppgaveId shouldBe null
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.saksnummer shouldBe saksnummer
+                journalposthendelseFraDB?.journalpostOppdatertTidspunkt shouldNotBe null
+                journalposthendelseFraDB?.journalpostFerdigstiltTidspunkt shouldNotBe null
+                journalposthendelseFraDB?.oppgaveId shouldBe null
+
+                coVerify(exactly = 0) { saksbehandlingApiClient.hentEllerOpprettSaksnummer(any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.knyttSakTilJournalpost(any(), any(), any()) }
+                coVerify(exactly = 1) {
+                    dokarkivClient.ferdigstillJournalpost(
+                        journalposthendelseDB.journalpostId,
+                        any(),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `oppdaterEllerFerdigstillJournalpost - papirsoknad, ferdigstilt - oppdaterer ingenting`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalpostService =
+                    JournalpostService(saksbehandlingApiClient, dokarkivClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = "4567",
+                    fnr = "12345678910",
+                    brevkode = Brevkode.SØKNAD.brevkode,
+                    saksnummer = saksnummer,
+                    journalpostOppdatertTidspunkt = LocalDateTime.now(),
+                    journalpostFerdigstiltTidspunkt = LocalDateTime.now(),
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                val returnertJournalposthendelseDB = journalpostService.oppdaterEllerFerdigstillJournalpost(
+                    journalposthendelseDB,
+                    CorrelationId.generate(),
+                )
+
+                returnertJournalposthendelseDB.saksnummer shouldBe saksnummer
+                returnertJournalposthendelseDB.journalpostOppdatertTidspunkt shouldNotBe null
+                returnertJournalposthendelseDB.journalpostFerdigstiltTidspunkt shouldNotBe null
+                returnertJournalposthendelseDB.oppgaveId shouldBe null
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.saksnummer shouldBe saksnummer
+                journalposthendelseFraDB?.journalpostOppdatertTidspunkt shouldNotBe null
+                journalposthendelseFraDB?.journalpostFerdigstiltTidspunkt shouldNotBe null
+                journalposthendelseFraDB?.oppgaveId shouldBe null
+
+                coVerify(exactly = 0) { saksbehandlingApiClient.hentEllerOpprettSaksnummer(any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.knyttSakTilJournalpost(any(), any(), any()) }
+                coVerify(exactly = 0) {
+                    dokarkivClient.ferdigstillJournalpost(
+                        any(),
+                        any(),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `oppdaterEllerFerdigstillJournalpost - klage - oppdaterer, ferdigstiller ikke`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalpostService =
+                    JournalpostService(saksbehandlingApiClient, dokarkivClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = "4567",
+                    fnr = "12345678910",
+                    brevkode = Brevkode.KLAGE.brevkode,
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                val returnertJournalposthendelseDB = journalpostService.oppdaterEllerFerdigstillJournalpost(
+                    journalposthendelseDB,
+                    CorrelationId.generate(),
+                )
+
+                returnertJournalposthendelseDB.saksnummer shouldBe saksnummer
+                returnertJournalposthendelseDB.journalpostOppdatertTidspunkt shouldNotBe null
+                returnertJournalposthendelseDB.journalpostFerdigstiltTidspunkt shouldBe null
+                returnertJournalposthendelseDB.oppgaveId shouldBe null
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.saksnummer shouldBe saksnummer
+                journalposthendelseFraDB?.journalpostOppdatertTidspunkt shouldNotBe null
+                journalposthendelseFraDB?.journalpostFerdigstiltTidspunkt shouldBe null
+                journalposthendelseFraDB?.oppgaveId shouldBe null
+
+                coVerify(exactly = 1) {
+                    saksbehandlingApiClient.hentEllerOpprettSaksnummer(
+                        journalposthendelseDB.fnr!!,
+                        any(),
+                    )
+                }
+                coVerify(exactly = 1) {
+                    dokarkivClient.knyttSakTilJournalpost(
+                        journalposthendelseDB.journalpostId,
+                        saksnummer,
+                        any(),
+                    )
+                }
+                coVerify(exactly = 0) {
+                    dokarkivClient.ferdigstillJournalpost(
+                        any(),
+                        any(),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `oppdaterEllerFerdigstillJournalpost - klage, allerede oppdatert - oppdaterer ingenting`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalpostService =
+                    JournalpostService(saksbehandlingApiClient, dokarkivClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = "4567",
+                    fnr = "12345678910",
+                    brevkode = Brevkode.KLAGE.brevkode,
+                    saksnummer = saksnummer,
+                    journalpostOppdatertTidspunkt = LocalDateTime.now(),
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                val returnertJournalposthendelseDB = journalpostService.oppdaterEllerFerdigstillJournalpost(
+                    journalposthendelseDB,
+                    CorrelationId.generate(),
+                )
+
+                returnertJournalposthendelseDB.saksnummer shouldBe saksnummer
+                returnertJournalposthendelseDB.journalpostOppdatertTidspunkt shouldNotBe null
+                returnertJournalposthendelseDB.journalpostFerdigstiltTidspunkt shouldBe null
+                returnertJournalposthendelseDB.oppgaveId shouldBe null
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.saksnummer shouldBe saksnummer
+                journalposthendelseFraDB?.journalpostOppdatertTidspunkt shouldNotBe null
+                journalposthendelseFraDB?.journalpostFerdigstiltTidspunkt shouldBe null
+                journalposthendelseFraDB?.oppgaveId shouldBe null
+
+                coVerify(exactly = 0) { saksbehandlingApiClient.hentEllerOpprettSaksnummer(any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.knyttSakTilJournalpost(any(), any(), any()) }
+                coVerify(exactly = 0) {
+                    dokarkivClient.ferdigstillJournalpost(
+                        any(),
+                        any(),
+                    )
+                }
+            }
+        }
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalposthendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/JournalposthendelseServiceTest.kt
@@ -1,0 +1,290 @@
+package no.nav.tiltakspenger.journalposthendelser.journalpost
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.Brevkode
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.JournalpostMetadata
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.dokarkiv.DokarkivClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.oppgave.OppgaveClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.oppgave.OppgaveType
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.pdl.PdlClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.saf.Bruker
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.saf.BrukerIdType
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.saf.SafJournalpostClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.saksbehandlingapi.SaksbehandlingApiClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.repository.JournalposthendelseDB
+import no.nav.tiltakspenger.journalposthendelser.journalpost.repository.JournalposthendelseRepo
+import no.nav.tiltakspenger.journalposthendelser.testutils.shouldBeCloseTo
+import no.nav.tiltakspenger.journalposthendelser.testutils.withMigratedDb
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class JournalposthendelseServiceTest {
+    private val safJournalpostClient = mockk<SafJournalpostClient>()
+    private val pdlClient = mockk<PdlClient>()
+    private val saksbehandlingApiClient = mockk<SaksbehandlingApiClient>()
+    private val dokarkivClient = mockk<DokarkivClient>(relaxed = true)
+    private val oppgaveClient = mockk<OppgaveClient>()
+    private val journalpostId = "4567"
+    private val fnr = "12345678910"
+    private val saksnummer = "34567"
+    private val oppgaveId = 9876
+    private val tittel = "Klage på tiltakspenger"
+
+    @BeforeEach
+    fun clearMockData() {
+        clearMocks(safJournalpostClient, pdlClient, saksbehandlingApiClient, dokarkivClient, oppgaveClient)
+        coEvery { pdlClient.hentGjeldendeIdent(any(), any()) } returns fnr
+        coEvery { saksbehandlingApiClient.hentEllerOpprettSaksnummer(any(), any()) } returns saksnummer
+        coEvery { oppgaveClient.opprettOppgaveForPapirsoknad(any(), any(), any()) } returns oppgaveId
+        coEvery { oppgaveClient.opprettJournalforingsoppgave(any(), any(), any(), any()) } returns oppgaveId
+        coEvery { oppgaveClient.opprettFordelingsoppgave(any(), any()) } returns oppgaveId
+    }
+
+    @Test
+    fun `behandleJournalpostHendelse - saf-klient returnerer ingen journalpost - kaster feil`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                coEvery { safJournalpostClient.getJournalpostMetadata(any()) } returns null
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalposthendelseService = getJournalposthendelseService(journalposthendelseRepo)
+
+                assertThrows<IllegalStateException> { journalposthendelseService.behandleJournalpostHendelse(journalpostId) }
+            }
+        }
+    }
+
+    @Test
+    fun `behandleJournalpostHendelse - journalpost er journalfort og finnes ikke i db - ignorerer journalposthendelse`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                coEvery { safJournalpostClient.getJournalpostMetadata(any()) } returns getJournalpostMetadata(erJournalfort = true)
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalposthendelseService = getJournalposthendelseService(journalposthendelseRepo)
+
+                journalposthendelseService.behandleJournalpostHendelse(journalpostId)
+
+                journalposthendelseRepo.hent(journalpostId) shouldBe null
+
+                coVerify(exactly = 0) { pdlClient.hentGjeldendeIdent(any(), any()) }
+                coVerify(exactly = 0) { saksbehandlingApiClient.hentEllerOpprettSaksnummer(any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.knyttSakTilJournalpost(any(), any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.ferdigstillJournalpost(any(), any()) }
+                coVerify(exactly = 0) { oppgaveClient.opprettOppgaveForPapirsoknad(any(), any(), any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `behandleJournalpostHendelse - journalpost er journalfort og ferdig behandlet i db - ignorerer journalposthendelse`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                coEvery { safJournalpostClient.getJournalpostMetadata(any()) } returns getJournalpostMetadata(erJournalfort = true)
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalposthendelseService = getJournalposthendelseService(journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = journalpostId,
+                    fnr = fnr,
+                    saksnummer = saksnummer,
+                    brevkode = Brevkode.SØKNAD.brevkode,
+                    journalpostOppdatertTidspunkt = LocalDateTime.now().minusMinutes(2),
+                    journalpostFerdigstiltTidspunkt = LocalDateTime.now().minusMinutes(2),
+                    oppgaveId = oppgaveId.toString(),
+                    oppgavetype = OppgaveType.BEHANDLE_SAK,
+                    oppgaveOpprettetTidspunkt = LocalDateTime.now().minusMinutes(1),
+                    opprettet = LocalDateTime.now().minusMinutes(2),
+                    sistEndret = LocalDateTime.now().minusMinutes(1),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                journalposthendelseService.behandleJournalpostHendelse(journalpostId)
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalpostId)
+                journalposthendelseFraDB shouldNotBe null
+                journalposthendelseFraDB?.sistEndret shouldBeCloseTo journalposthendelseDB.sistEndret
+
+                coVerify(exactly = 0) { pdlClient.hentGjeldendeIdent(any(), any()) }
+                coVerify(exactly = 0) { saksbehandlingApiClient.hentEllerOpprettSaksnummer(any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.knyttSakTilJournalpost(any(), any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.ferdigstillJournalpost(any(), any()) }
+                coVerify(exactly = 0) { oppgaveClient.opprettOppgaveForPapirsoknad(any(), any(), any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `behandleJournalpostHendelse - journalpost er journalfort og ikke ferdig behandlet i db - behandler journalposthendelse`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                coEvery { safJournalpostClient.getJournalpostMetadata(any()) } returns getJournalpostMetadata(erJournalfort = true)
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalposthendelseService = getJournalposthendelseService(journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = journalpostId,
+                    fnr = fnr,
+                    saksnummer = saksnummer,
+                    brevkode = Brevkode.SØKNAD.brevkode,
+                    journalpostOppdatertTidspunkt = LocalDateTime.now().minusMinutes(2),
+                    journalpostFerdigstiltTidspunkt = LocalDateTime.now().minusMinutes(2),
+                    opprettet = LocalDateTime.now().minusMinutes(2),
+                    sistEndret = LocalDateTime.now().minusMinutes(2),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                journalposthendelseService.behandleJournalpostHendelse(journalpostId)
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalpostId)
+                journalposthendelseFraDB shouldNotBe null
+                journalposthendelseFraDB?.oppgaveId shouldBe oppgaveId.toString()
+                journalposthendelseFraDB?.oppgavetype shouldBe OppgaveType.BEHANDLE_SAK
+                journalposthendelseFraDB?.oppgaveOpprettetTidspunkt shouldBeCloseTo LocalDateTime.now()
+                journalposthendelseFraDB?.sistEndret shouldBeCloseTo LocalDateTime.now()
+
+                coVerify(exactly = 1) { pdlClient.hentGjeldendeIdent(fnr, journalpostId) }
+                coVerify(exactly = 0) { saksbehandlingApiClient.hentEllerOpprettSaksnummer(any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.knyttSakTilJournalpost(any(), any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.ferdigstillJournalpost(any(), any()) }
+                coVerify(exactly = 1) { oppgaveClient.opprettOppgaveForPapirsoknad(fnr, journalpostId, any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `behandleJournalpostHendelse - ikke behandlet, mangler bruker - oppretter fordelingsoppgave`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                coEvery { safJournalpostClient.getJournalpostMetadata(any()) } returns getJournalpostMetadata(brukerId = null)
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalposthendelseService = getJournalposthendelseService(journalposthendelseRepo)
+
+                journalposthendelseService.behandleJournalpostHendelse(journalpostId)
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalpostId)
+                journalposthendelseFraDB shouldNotBe null
+                journalposthendelseFraDB?.fnr shouldBe null
+                journalposthendelseFraDB?.saksnummer shouldBe null
+                journalposthendelseFraDB?.brevkode shouldBe Brevkode.SØKNAD.brevkode
+                journalposthendelseFraDB?.journalpostOppdatertTidspunkt shouldBe null
+                journalposthendelseFraDB?.journalpostFerdigstiltTidspunkt shouldBe null
+                journalposthendelseFraDB?.oppgaveId shouldBe oppgaveId.toString()
+                journalposthendelseFraDB?.oppgavetype shouldBe OppgaveType.FORDELING
+                journalposthendelseFraDB?.oppgaveOpprettetTidspunkt shouldBeCloseTo LocalDateTime.now()
+                journalposthendelseFraDB?.sistEndret shouldBeCloseTo LocalDateTime.now()
+
+                coVerify(exactly = 0) { pdlClient.hentGjeldendeIdent(any(), any()) }
+                coVerify(exactly = 0) { saksbehandlingApiClient.hentEllerOpprettSaksnummer(any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.knyttSakTilJournalpost(any(), any(), any()) }
+                coVerify(exactly = 0) { dokarkivClient.ferdigstillJournalpost(any(), any()) }
+                coVerify(exactly = 1) { oppgaveClient.opprettFordelingsoppgave(journalpostId, any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `behandleJournalpostHendelse - ikke behandlet, klage - oppretter journalforingsoppgave`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val aktorId = "2345432"
+                coEvery { safJournalpostClient.getJournalpostMetadata(any()) } returns getJournalpostMetadata(
+                    brukerId = aktorId,
+                    brukerIdType = BrukerIdType.AKTOERID,
+                    brevkode = Brevkode.KLAGE,
+                )
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalposthendelseService = getJournalposthendelseService(journalposthendelseRepo)
+
+                journalposthendelseService.behandleJournalpostHendelse(journalpostId)
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalpostId)
+                journalposthendelseFraDB shouldNotBe null
+                journalposthendelseFraDB?.fnr shouldBe fnr
+                journalposthendelseFraDB?.saksnummer shouldBe saksnummer
+                journalposthendelseFraDB?.brevkode shouldBe Brevkode.KLAGE.brevkode
+                journalposthendelseFraDB?.journalpostOppdatertTidspunkt shouldBeCloseTo LocalDateTime.now()
+                journalposthendelseFraDB?.journalpostFerdigstiltTidspunkt shouldBe null
+                journalposthendelseFraDB?.oppgaveId shouldBe oppgaveId.toString()
+                journalposthendelseFraDB?.oppgavetype shouldBe OppgaveType.JOURNALFORING
+                journalposthendelseFraDB?.oppgaveOpprettetTidspunkt shouldBeCloseTo LocalDateTime.now()
+                journalposthendelseFraDB?.sistEndret shouldBeCloseTo LocalDateTime.now()
+
+                coVerify(exactly = 1) { pdlClient.hentGjeldendeIdent(aktorId, journalpostId) }
+                coVerify(exactly = 1) { saksbehandlingApiClient.hentEllerOpprettSaksnummer(fnr, any()) }
+                coVerify(exactly = 1) { dokarkivClient.knyttSakTilJournalpost(journalpostId, saksnummer, any()) }
+                coVerify(exactly = 0) { dokarkivClient.ferdigstillJournalpost(any(), any()) }
+                coVerify(exactly = 1) { oppgaveClient.opprettJournalforingsoppgave(fnr, journalpostId, tittel, any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `behandleJournalpostHendelse - ikke behandlet, papirsoknad - journalforer og oppretter behandle sak-oppgave`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                coEvery { safJournalpostClient.getJournalpostMetadata(any()) } returns getJournalpostMetadata()
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val journalposthendelseService = getJournalposthendelseService(journalposthendelseRepo)
+
+                journalposthendelseService.behandleJournalpostHendelse(journalpostId)
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalpostId)
+                journalposthendelseFraDB shouldNotBe null
+                journalposthendelseFraDB?.fnr shouldBe fnr
+                journalposthendelseFraDB?.saksnummer shouldBe saksnummer
+                journalposthendelseFraDB?.brevkode shouldBe Brevkode.SØKNAD.brevkode
+                journalposthendelseFraDB?.journalpostOppdatertTidspunkt shouldBeCloseTo LocalDateTime.now()
+                journalposthendelseFraDB?.journalpostFerdigstiltTidspunkt shouldBeCloseTo LocalDateTime.now()
+                journalposthendelseFraDB?.oppgaveId shouldBe oppgaveId.toString()
+                journalposthendelseFraDB?.oppgavetype shouldBe OppgaveType.BEHANDLE_SAK
+                journalposthendelseFraDB?.oppgaveOpprettetTidspunkt shouldBeCloseTo LocalDateTime.now()
+                journalposthendelseFraDB?.sistEndret shouldBeCloseTo LocalDateTime.now()
+
+                coVerify(exactly = 1) { pdlClient.hentGjeldendeIdent(fnr, journalpostId) }
+                coVerify(exactly = 1) { saksbehandlingApiClient.hentEllerOpprettSaksnummer(fnr, any()) }
+                coVerify(exactly = 1) { dokarkivClient.knyttSakTilJournalpost(journalpostId, saksnummer, any()) }
+                coVerify(exactly = 1) { dokarkivClient.ferdigstillJournalpost(journalpostId, any()) }
+                coVerify(exactly = 1) { oppgaveClient.opprettOppgaveForPapirsoknad(fnr, journalpostId, any()) }
+            }
+        }
+    }
+
+    private fun getJournalpostMetadata(
+        journalpostId: String = this.journalpostId,
+        brukerId: String? = fnr,
+        brukerIdType: BrukerIdType? = BrukerIdType.FNR,
+        erJournalfort: Boolean = false,
+        brevkode: Brevkode? = Brevkode.SØKNAD,
+    ) =
+        JournalpostMetadata(
+            journalpostId = journalpostId,
+            bruker = Bruker(
+                id = brukerId,
+                type = brukerIdType,
+            ),
+            erJournalfort = erJournalfort,
+            datoOpprettet = LocalDateTime.now().minusMinutes(2),
+            brevkode = brevkode?.brevkode,
+            tittel = tittel,
+        )
+
+    private fun getJournalposthendelseService(journalposthendelseRepo: JournalposthendelseRepo) = JournalposthendelseService(
+        safJournalpostClient = safJournalpostClient,
+        journalposthendelseRepo = journalposthendelseRepo,
+        pdlClient = pdlClient,
+        journalpostService = JournalpostService(
+            saksbehandlingApiClient = saksbehandlingApiClient,
+            dokarkivClient = dokarkivClient,
+            journalposthendelseRepo = journalposthendelseRepo,
+        ),
+        oppgaveService = OppgaveService(
+            oppgaveClient = oppgaveClient,
+            journalposthendelseRepo = journalposthendelseRepo,
+        ),
+    )
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/OppgaveServiceTest.kt
@@ -1,0 +1,234 @@
+package no.nav.tiltakspenger.journalposthendelser.journalpost
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.Brevkode
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.oppgave.OppgaveClient
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.oppgave.OppgaveType
+import no.nav.tiltakspenger.journalposthendelser.journalpost.repository.JournalposthendelseDB
+import no.nav.tiltakspenger.journalposthendelser.testutils.withMigratedDb
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class OppgaveServiceTest {
+    private val oppgaveClient = mockk<OppgaveClient>()
+    private val journalpostId = "4567"
+    private val fnr = "12345678910"
+    private val saksnummer = "34567"
+    private val oppgaveId = 9876
+    private val tittel = "Klage på tiltakspenger"
+
+    @BeforeEach
+    fun clearMockData() {
+        clearMocks(oppgaveClient)
+        coEvery { oppgaveClient.opprettOppgaveForPapirsoknad(any(), any(), any()) } returns oppgaveId
+        coEvery { oppgaveClient.opprettJournalforingsoppgave(any(), any(), any(), any()) } returns oppgaveId
+        coEvery { oppgaveClient.opprettFordelingsoppgave(any(), any()) } returns oppgaveId
+    }
+
+    @Test
+    fun `opprettOppgaveForPapirsoknad - papirsoknad - oppretter oppgave`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val oppgaveService = OppgaveService(oppgaveClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = journalpostId,
+                    fnr = fnr,
+                    brevkode = Brevkode.SØKNAD.brevkode,
+                    saksnummer = saksnummer,
+                    journalpostOppdatertTidspunkt = LocalDateTime.now(),
+                    journalpostFerdigstiltTidspunkt = LocalDateTime.now(),
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                oppgaveService.opprettOppgaveForPapirsoknad(
+                    journalposthendelseDB,
+                    CorrelationId.generate(),
+                )
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.oppgaveId shouldBe oppgaveId.toString()
+                journalposthendelseFraDB?.oppgavetype shouldBe OppgaveType.BEHANDLE_SAK
+                journalposthendelseFraDB?.oppgaveOpprettetTidspunkt shouldNotBe null
+
+                coVerify(exactly = 1) { oppgaveClient.opprettOppgaveForPapirsoknad(fnr, journalpostId, any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `opprettOppgaveForPapirsoknad - papirsoknad, har opprettet oppgave - oppretter ingenting`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val oppgaveService = OppgaveService(oppgaveClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = journalpostId,
+                    fnr = fnr,
+                    brevkode = Brevkode.SØKNAD.brevkode,
+                    saksnummer = saksnummer,
+                    journalpostOppdatertTidspunkt = LocalDateTime.now(),
+                    journalpostFerdigstiltTidspunkt = LocalDateTime.now(),
+                    oppgaveId = oppgaveId.toString(),
+                    oppgavetype = OppgaveType.BEHANDLE_SAK,
+                    oppgaveOpprettetTidspunkt = LocalDateTime.now(),
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                oppgaveService.opprettOppgaveForPapirsoknad(
+                    journalposthendelseDB,
+                    CorrelationId.generate(),
+                )
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.oppgaveId shouldBe oppgaveId.toString()
+                journalposthendelseFraDB?.oppgavetype shouldBe OppgaveType.BEHANDLE_SAK
+                journalposthendelseFraDB?.oppgaveOpprettetTidspunkt shouldNotBe null
+
+                coVerify(exactly = 0) { oppgaveClient.opprettOppgaveForPapirsoknad(any(), any(), any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `opprettJournalforingsoppgave - klage - oppretter oppgave`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val oppgaveService = OppgaveService(oppgaveClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = journalpostId,
+                    fnr = fnr,
+                    brevkode = Brevkode.KLAGE.brevkode,
+                    saksnummer = saksnummer,
+                    journalpostOppdatertTidspunkt = LocalDateTime.now(),
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                oppgaveService.opprettJournalforingsoppgave(
+                    journalposthendelseDB,
+                    tittel,
+                    CorrelationId.generate(),
+                )
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.oppgaveId shouldBe oppgaveId.toString()
+                journalposthendelseFraDB?.oppgavetype shouldBe OppgaveType.JOURNALFORING
+                journalposthendelseFraDB?.oppgaveOpprettetTidspunkt shouldNotBe null
+
+                coVerify(exactly = 1) { oppgaveClient.opprettJournalforingsoppgave(fnr, journalpostId, tittel, any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `opprettJournalforingsoppgave - klage, har opprettet oppgave - oppretter ingenting`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val oppgaveService = OppgaveService(oppgaveClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = journalpostId,
+                    fnr = fnr,
+                    brevkode = Brevkode.KLAGE.brevkode,
+                    saksnummer = saksnummer,
+                    journalpostOppdatertTidspunkt = LocalDateTime.now(),
+                    oppgaveId = oppgaveId.toString(),
+                    oppgavetype = OppgaveType.JOURNALFORING,
+                    oppgaveOpprettetTidspunkt = LocalDateTime.now(),
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                oppgaveService.opprettJournalforingsoppgave(
+                    journalposthendelseDB,
+                    tittel,
+                    CorrelationId.generate(),
+                )
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.oppgaveId shouldBe oppgaveId.toString()
+                journalposthendelseFraDB?.oppgavetype shouldBe OppgaveType.JOURNALFORING
+                journalposthendelseFraDB?.oppgaveOpprettetTidspunkt shouldNotBe null
+
+                coVerify(exactly = 0) { oppgaveClient.opprettJournalforingsoppgave(any(), any(), any(), any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `opprettFordelingsoppgave - klage - oppretter oppgave`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val oppgaveService = OppgaveService(oppgaveClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = journalpostId,
+                    brevkode = Brevkode.KLAGE.brevkode,
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                oppgaveService.opprettFordelingsoppgave(
+                    journalposthendelseDB,
+                    CorrelationId.generate(),
+                )
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.oppgaveId shouldBe oppgaveId.toString()
+                journalposthendelseFraDB?.oppgavetype shouldBe OppgaveType.FORDELING
+                journalposthendelseFraDB?.oppgaveOpprettetTidspunkt shouldNotBe null
+
+                coVerify(exactly = 1) { oppgaveClient.opprettFordelingsoppgave(journalpostId, any()) }
+            }
+        }
+    }
+
+    @Test
+    fun `opprettFordelingsoppgave - klage, har opprettet oppgave - oppretter ingenting`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runTest {
+                val journalposthendelseRepo = testDataHelper.journalposthendelseRepo
+                val oppgaveService = OppgaveService(oppgaveClient, journalposthendelseRepo)
+                val journalposthendelseDB = JournalposthendelseDB(
+                    journalpostId = journalpostId,
+                    brevkode = Brevkode.KLAGE.brevkode,
+                    oppgaveId = oppgaveId.toString(),
+                    oppgavetype = OppgaveType.FORDELING,
+                    oppgaveOpprettetTidspunkt = LocalDateTime.now(),
+                    opprettet = LocalDateTime.now(),
+                    sistEndret = LocalDateTime.now(),
+                )
+                journalposthendelseRepo.lagre(journalposthendelseDB)
+
+                oppgaveService.opprettFordelingsoppgave(
+                    journalposthendelseDB,
+                    CorrelationId.generate(),
+                )
+
+                val journalposthendelseFraDB = journalposthendelseRepo.hent(journalposthendelseDB.journalpostId)
+                journalposthendelseFraDB?.oppgaveId shouldBe oppgaveId.toString()
+                journalposthendelseFraDB?.oppgavetype shouldBe OppgaveType.FORDELING
+                journalposthendelseFraDB?.oppgaveOpprettetTidspunkt shouldNotBe null
+
+                coVerify(exactly = 0) { oppgaveClient.opprettFordelingsoppgave(any(), any()) }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/journalposthendelser/journalpost/repository/JournalposthendelseRepoTest.kt
@@ -2,6 +2,7 @@ package no.nav.tiltakspenger.journalposthendelser.journalpost.repository
 
 import io.kotest.matchers.shouldBe
 import no.nav.tiltakspenger.journalposthendelser.journalpost.domene.Brevkode
+import no.nav.tiltakspenger.journalposthendelser.journalpost.http.oppgave.OppgaveType
 import no.nav.tiltakspenger.journalposthendelser.testutils.shouldBeCloseTo
 import no.nav.tiltakspenger.journalposthendelser.testutils.withMigratedDb
 import org.junit.jupiter.api.Test
@@ -20,7 +21,7 @@ class JournalposthendelseRepoTest {
                 journalpostOppdatertTidspunkt = LocalDateTime.now().minusMinutes(3),
                 journalpostFerdigstiltTidspunkt = LocalDateTime.now().minusMinutes(2),
                 oppgaveId = "900000",
-                oppgavetype = "BEHANDLE_SAK",
+                oppgavetype = OppgaveType.BEHANDLE_SAK,
                 oppgaveOpprettetTidspunkt = LocalDateTime.now().minusMinutes(1),
                 opprettet = LocalDateTime.now().minusMinutes(5),
                 sistEndret = LocalDateTime.now(),
@@ -63,7 +64,7 @@ class JournalposthendelseRepoTest {
 
             val oppdatertJournalposthendelseDB = journalposthendelseDB.copy(
                 oppgaveId = "900000",
-                oppgavetype = "BEHANDLE_SAK",
+                oppgavetype = OppgaveType.BEHANDLE_SAK,
                 oppgaveOpprettetTidspunkt = LocalDateTime.now().minusMinutes(1),
                 sistEndret = LocalDateTime.now(),
             )


### PR DESCRIPTION
Måtte omstrukturere litt så det forhåpentligvis blir mer oversiktlig. Det som dreier seg om beriking/oppdatering/ferdigstilling av journalposten ligger i JournalpostService. At som gjelder oppretting av oppgave ligger i OppgaveService. Og JournalposthendelseService er den som styrer selve behandlingen av den leste journalposten (hva skal behandles, henting av metadata og bruker, osv). Vi oppdaterer arbeidstabellen i databasen når vi har gjort en endring som ikke skal gjøres på nytt (f.eks. oppdatere/ferdigstille journalpost). 


https://trello.com/c/hAyNLNOc/1595-h%C3%A5ndtere-alle-journalposthendelser-som-gjelder-tiltakspenger-inkludert-scannede-papirs%C3%B8knader-toggles-av-i-prod